### PR TITLE
Makefile: add standard GNU makefiles directory variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ CFLAGS := -Wall -g
 LDFLAGS :=
 
 prefix := /usr/local
+bindir := $(prefix)/bin
+libdir := $(prefix)/lib
+includedir := $(prefix)/include
 
 ifneq ($(CROSS_COMPILE),)
 CC := $(CROSS_COMPILE)gcc
@@ -56,11 +59,11 @@ endif
 	@$(CC) -o $@ -c $< $(CFLAGS) $(_CFLAGS)
 
 define add-inc-target
-$(DESTDIR)$(prefix)/include/$2: $1/$2
+$(DESTDIR)$(includedir)/$2: $1/$2
 	@echo "INSTALL	$$<"
 	@install -D -m 755 $$< $$@
 
-all-install += $(DESTDIR)$(prefix)/include/$2
+all-install += $(DESTDIR)$(includedir)/$2
 endef
 
 define add-target-deps
@@ -79,11 +82,11 @@ $1: $(call src_to_obj,$($1-srcs))
 	@echo "LD	$$@"
 	$$(CC) -o $$@ $$(filter %.o,$$^) $(LDFLAGS) -static
 
-$(DESTDIR)$(prefix)/bin/$1: $1
+$(DESTDIR)$(bindir)/$1: $1
 	@echo "INSTALL	$$<"
 	@install -D -m 755 $$< $$@
 
-all-install += $(DESTDIR)$(prefix)/bin/$1
+all-install += $(DESTDIR)$(bindir)/$1
 endef
 
 define add-lib-target
@@ -94,13 +97,13 @@ $1: $(call src_to_obj,$($1-srcs))
 	@echo "LD	$$@"
 	$$(CC) -o $$@ $$(filter %.o,$$^) $(LDFLAGS) -shared -Wl,-soname,$1.$(proj-major)
 
-$(DESTDIR)$(prefix)/lib/$1.$(proj-version): $1
+$(DESTDIR)$(libdir)/$1.$(proj-version): $1
 	@echo "INSTALL	$$<"
 	@install -D -m 755 $$< $$@
-	@ln -sf $1.$(proj-version) $(DESTDIR)$(prefix)/lib/$1.$(proj-major)
-	@ln -sf $1.$(proj-major) $(DESTDIR)$(prefix)/lib/$1
+	@ln -sf $1.$(proj-version) $(DESTDIR)$(libdir)/$1.$(proj-major)
+	@ln -sf $1.$(proj-major) $(DESTDIR)$(libdir)/$1
 
-all-install += $(DESTDIR)$(prefix)/lib/$1.$(proj-version)
+all-install += $(DESTDIR)$(libdir)/$1.$(proj-version)
 endef
 
 $(foreach v,$(filter-out %.so,$(targets)),$(eval $(call add-bin-target,$v)))


### PR DESCRIPTION
This component is compiled in Debian and OE where we have multilib support
enabled by default, so let's use proper variables for Makefile so that distro
can better configure the destination folders.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>