### PR TITLE
Makefile: fix compilation of qrtr-cfg target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ SFLAGS := -I$(shell $(CC) -print-file-name=include) -Wno-non-pointer-null
 $(proj)-cfg-srcs := \
 	src/cfg.c
 
+$(proj)-cfg-cflags := -Ilib
+
 $(proj)-ns-srcs := \
 	src/ns.c \
 	src/map.c \


### PR DESCRIPTION
This patch adds a missing -Ilib to CFLAGS for the qrtr-cfg target as
src/cfg.c needs to include lib/libqrtr.h.

Signed-off-by: Ben Chan <benchan@chromium.org>