### PR TITLE
libqrtr: define AF_QIPCRTR if it isn't defined in libc header

### DIFF
--- a/lib/libqrtr.h
+++ b/lib/libqrtr.h
@@ -15,6 +15,10 @@
   ((type *)((char *)(ptr) - offsetof(type, member)))
 #endif
 
+#ifndef AF_QIPCRTR
+#define AF_QIPCRTR 42
+#endif
+
 struct sockaddr_qrtr;
 
 struct qrtr_packet {


### PR DESCRIPTION
Definition of AF_QIPCRTR was introduced in glibc in the following
commit and is only available since glibc 2.25 or later.

https://sourceware.org/git/?p=glibc.git;a=commit;h=acaff9b658720e4c887f4e44e6f28962d6f372d3

This patch modifies libqrtr.h to define AF_QIPCRTR if it isn't defined
in libc header, which allows compilation of libqrtr on a system with an
older version of glibc. The compiled libqrtr can still be used on a
system with kernel 4.7 or later with the QIPCRTR support.

Signed-off-by: Ben Chan <benchan@chromium.org>