### PR TITLE
qmi: remove unused include

### DIFF
--- a/lib/qmi.c
+++ b/lib/qmi.c
@@ -27,7 +27,6 @@
  * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
  * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-#include <err.h>
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
This include provides err, errx, etc. but it looks like all
error logging in qmi.c is done with fprintf, so there's no
reason to include it.