### PR TITLE
Minor cleanup

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -1,5 +1,6 @@
 #include <err.h>
 #include <errno.h>
+#include <libgen.h>
 #include <limits.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
@@ -13,11 +14,9 @@
 
 #include "libqrtr.h"
 
-static void usage(void)
+static void usage(const char *progname)
 {
-	extern char *__progname;
-
-	fprintf(stderr, "%s <node-id>\n", __progname);
+	fprintf(stderr, "%s <node-id>\n", progname);
 	exit(1);
 }
 
@@ -38,13 +37,14 @@ int main(int argc, char **argv)
 	char *ep;
 	int sock;
 	int ret;
+	const char *progname = basename(argv[0]);
 
 	if (argc != 2)
-		usage();
+		usage(progname);
 
 	addrul = strtoul(argv[1], &ep, 10);
 	if (argv[1][0] == '\0' || *ep != '\0' || addrul >= UINT_MAX)
-		usage();
+		usage(progname);
 	addr = addrul;
 
 	/* Trigger loading of the qrtr kernel module */

--- a/src/lookup.c
+++ b/src/lookup.c
@@ -1,17 +1,17 @@
+#include <err.h>
+#include <errno.h>
+#include <linux/qrtr.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <linux/qrtr.h>
 #include <unistd.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
-#include <errno.h>
-#include <err.h>
 
 #include "libqrtr.h"
-#include "util.h"
 #include "ns.h"
+#include "util.h"
 
 static const struct {
 	unsigned int service;

--- a/src/lookup.c
+++ b/src/lookup.c
@@ -1,5 +1,6 @@
 #include <err.h>
 #include <errno.h>
+#include <libgen.h>
 #include <linux/qrtr.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -103,6 +104,7 @@ int main(int argc, char **argv)
 	int sock;
 	int len;
 	int rc;
+	const char *progname = basename(argv[0]);
 
 	rc = 0;
 	memset(&pkt, 0, sizeof(pkt));
@@ -116,7 +118,7 @@ int main(int argc, char **argv)
 	case 1: break;
 	}
 	if (rc)
-		errx(1, "Usage: %s [<service> [<instance> [<filter>]]]", argv[0]);
+		errx(1, "Usage: %s [<service> [<instance> [<filter>]]]", progname);
 
 	sock = socket(AF_QIPCRTR, SOCK_DGRAM, 0);
 	if (sock < 0)

--- a/src/ns.c
+++ b/src/ns.c
@@ -1,5 +1,6 @@
 #include <err.h>
 #include <errno.h>
+#include <libgen.h>
 #include <limits.h>
 #include <linux/qrtr.h>
 #include <linux/netlink.h>
@@ -746,11 +747,9 @@ static void qrtr_set_address(uint32_t addr)
 	close(sock);
 }
 
-static void usage(void)
+static void usage(const char *progname)
 {
-	extern char *__progname;
-
-	fprintf(stderr, "%s [-f] [<node-id>]\n", __progname);
+	fprintf(stderr, "%s [-f] [<node-id>]\n", progname);
 	exit(1);
 }
 
@@ -766,6 +765,7 @@ int main(int argc, char **argv)
 	char *ep;
 	int opt;
 	int rc;
+	const char *progname = basename(argv[0]);
 
 	while ((opt = getopt(argc, argv, "f")) != -1) {
 		switch (opt) {
@@ -773,21 +773,21 @@ int main(int argc, char **argv)
 			foreground = true;
 			break;
 		default:
-			usage();
+			usage(progname);
 		}
 	}
 
 	if (optind < argc) {
 		addr = strtoul(argv[optind], &ep, 10);
 		if (argv[1][0] == '\0' || *ep != '\0' || addr >= UINT_MAX)
-			usage();
+			usage(progname);
 
 		qrtr_set_address(addr);
 		optind++;
 	}
 
 	if (optind != argc)
-		usage();
+		usage(progname);
 
 	w = waiter_create();
 	if (w == NULL)

--- a/src/ns.c
+++ b/src/ns.c
@@ -1,24 +1,24 @@
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <linux/qrtr.h>
-#include <linux/netlink.h>
-#include <linux/rtnetlink.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <string.h>
-#include <stdio.h>
 #include <err.h>
 #include <errno.h>
 #include <limits.h>
+#include <linux/qrtr.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
-#include "map.h"
 #include "hash.h"
-#include "waiter.h"
 #include "list.h"
-#include "util.h"
+#include "map.h"
 #include "ns.h"
+#include "util.h"
+#include "waiter.h"
 
 #include "libqrtr.h"
 


### PR DESCRIPTION
In the future I plan to add log-to-syslog functionality so that we can log there directly instead of always logging to stderr. This will simplify our upstart configuration. The basename of argv[0] will be useful as the tag, and as long as we're pulling it out of argv[0] we can use it in the usage message instead of non-portable __progname.