### PR TITLE
cfg, ns: factor out qrtr_set_address function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,13 @@ endif
 SFLAGS := -I$(shell $(CC) -print-file-name=include) -Wno-non-pointer-null
 
 $(proj)-cfg-srcs := \
-	src/cfg.c
+	src/addr.c \
+	src/cfg.c \
 
 $(proj)-cfg-cflags := -Ilib
 
 $(proj)-ns-srcs := \
+	src/addr.c \
 	src/ns.c \
 	src/map.c \
 	src/hash.c \

--- a/src/addr.c
+++ b/src/addr.c
@@ -1,0 +1,77 @@
+#include <err.h>
+#include <errno.h>
+#include <linux/qrtr.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "libqrtr.h"
+
+void qrtr_set_address(uint32_t addr)
+{
+	struct {
+		struct nlmsghdr nh;
+		struct ifaddrmsg ifa;
+		char attrbuf[32];
+	} req;
+	struct {
+		struct nlmsghdr nh;
+		struct nlmsgerr err;
+	} resp;
+	struct sockaddr_qrtr sq;
+	struct rtattr *rta;
+	socklen_t sl = sizeof(sq);
+	int sock;
+	int ret;
+
+	/* Trigger loading of the qrtr kernel module */
+	sock = socket(AF_QIPCRTR, SOCK_DGRAM, 0);
+	if (sock < 0)
+		err(1, "failed to create AF_QIPCRTR socket");
+
+	ret = getsockname(sock, (void*)&sq, &sl);
+	if (ret < 0)
+		err(1, "getsockname()");
+	close(sock);
+
+	/* Skip configuring the address, if it's same as current */
+	if (sl == sizeof(sq) && sq.sq_node == addr)
+		return;
+
+	sock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
+	if (sock < 0)
+		err(1, "failed to create netlink socket");
+
+	memset(&req, 0, sizeof(req));
+	req.nh.nlmsg_len = NLMSG_SPACE(sizeof(struct ifaddrmsg));
+	req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+	req.nh.nlmsg_type = RTM_NEWADDR;
+	req.ifa.ifa_family = AF_QIPCRTR;
+
+	rta = (struct rtattr *)(((char *) &req) + req.nh.nlmsg_len);
+	rta->rta_type = IFA_LOCAL;
+	rta->rta_len = RTA_LENGTH(sizeof(addr));
+	memcpy(RTA_DATA(rta), &addr, sizeof(addr));
+
+	req.nh.nlmsg_len += rta->rta_len;
+
+	ret = send(sock, &req, req.nh.nlmsg_len, 0);
+	if (ret < 0)
+		err(1, "failed to send netlink request");
+
+	ret = recv(sock, &resp, sizeof(resp), 0);
+	if (ret < 0)
+		err(1, "failed to receive netlink response");
+
+	if (resp.nh.nlmsg_type == NLMSG_ERROR && resp.err.error != 0) {
+		errno = -resp.err.error;
+		err(1, "failed to configure node id");
+	}
+
+	close(sock);
+}
+

--- a/src/addr.h
+++ b/src/addr.h
@@ -1,0 +1,8 @@
+#ifndef __ADDR_H_
+#define __ADDR_H_
+
+#include <stdint.h>
+
+void qrtr_set_address(uint32_t addr);
+
+#endif

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "addr.h"
 #include "libqrtr.h"
 
 static void usage(void)
@@ -23,21 +24,9 @@ static void usage(void)
 
 int main(int argc, char **argv)
 {
-	struct {
-		struct nlmsghdr nh;
-		struct ifaddrmsg ifa;
-		char attrbuf[32];
-	} req;
-	struct {
-		struct nlmsghdr nh;
-		struct nlmsgerr err;
-	} resp;
-	struct rtattr *rta;
 	unsigned long addrul;
 	uint32_t addr;
 	char *ep;
-	int sock;
-	int ret;
 
 	if (argc != 2)
 		usage();
@@ -46,42 +35,7 @@ int main(int argc, char **argv)
 	if (argv[1][0] == '\0' || *ep != '\0' || addrul >= UINT_MAX)
 		usage();
 	addr = addrul;
-
-	/* Trigger loading of the qrtr kernel module */
-	sock = socket(AF_QIPCRTR, SOCK_DGRAM, 0);
-	if (sock < 0)
-		err(1, "failed to create AF_QIPCRTR socket");
-	close(sock);
-
-	sock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
-	if (sock < 0)
-		err(1, "failed to create netlink socket");
-
-	memset(&req, 0, sizeof(req));
-	req.nh.nlmsg_len = NLMSG_SPACE(sizeof(struct ifaddrmsg));
-	req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
-	req.nh.nlmsg_type = RTM_NEWADDR;
-	req.ifa.ifa_family = AF_QIPCRTR;
-
-	rta = (struct rtattr *)(((char *) &req) + req.nh.nlmsg_len);
-	rta->rta_type = IFA_LOCAL;
-	rta->rta_len = RTA_LENGTH(sizeof(addr));
-	memcpy(RTA_DATA(rta), &addr, sizeof(addr));
-
-	req.nh.nlmsg_len += rta->rta_len;
-
-	ret = send(sock, &req, req.nh.nlmsg_len, 0);
-	if (ret < 0)
-		err(1, "failed to send netlink request");
-
-	ret = recv(sock, &resp, sizeof(resp), 0);
-	if (ret < 0)
-		err(1, "failed to receive netlink response");
-
-	if (resp.nh.nlmsg_type == NLMSG_ERROR && resp.err.error != 0) {
-		errno = -resp.err.error;
-		err(1, "failed to configure node id");
-	}
+	qrtr_set_address(addr);
 
 	return 0;
 }

--- a/src/ns.c
+++ b/src/ns.c
@@ -13,6 +13,7 @@
 #include <errno.h>
 #include <limits.h>
 
+#include "addr.h"
 #include "map.h"
 #include "hash.h"
 #include "waiter.h"
@@ -680,70 +681,6 @@ static void node_mi_free(struct map_item *mi)
 	map_destroy(&node->services);
 
 	free(node);
-}
-
-static void qrtr_set_address(uint32_t addr)
-{
-	struct {
-		struct nlmsghdr nh;
-		struct ifaddrmsg ifa;
-		char attrbuf[32];
-	} req;
-	struct {
-		struct nlmsghdr nh;
-		struct nlmsgerr err;
-	} resp;
-	struct sockaddr_qrtr sq;
-	struct rtattr *rta;
-	socklen_t sl = sizeof(sq);
-	int sock;
-	int ret;
-
-	/* Trigger loading of the qrtr kernel module */
-	sock = socket(AF_QIPCRTR, SOCK_DGRAM, 0);
-	if (sock < 0)
-		err(1, "failed to create AF_QIPCRTR socket");
-
-	ret = getsockname(sock, (void*)&sq, &sl);
-	if (ret < 0)
-		err(1, "getsockname()");
-	close(sock);
-
-	/* Skip configuring the address, if it's same as current */
-	if (sl == sizeof(sq) && sq.sq_node == addr)
-		return;
-
-	sock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
-	if (sock < 0)
-		err(1, "failed to create netlink socket");
-
-	memset(&req, 0, sizeof(req));
-	req.nh.nlmsg_len = NLMSG_SPACE(sizeof(struct ifaddrmsg));
-	req.nh.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
-	req.nh.nlmsg_type = RTM_NEWADDR;
-	req.ifa.ifa_family = AF_QIPCRTR;
-
-	rta = (struct rtattr *)(((char *) &req) + req.nh.nlmsg_len);
-	rta->rta_type = IFA_LOCAL;
-	rta->rta_len = RTA_LENGTH(sizeof(addr));
-	memcpy(RTA_DATA(rta), &addr, sizeof(addr));
-
-	req.nh.nlmsg_len += rta->rta_len;
-
-	ret = send(sock, &req, req.nh.nlmsg_len, 0);
-	if (ret < 0)
-		err(1, "failed to send netlink request");
-
-	ret = recv(sock, &resp, sizeof(resp), 0);
-	if (ret < 0)
-		err(1, "failed to receive netlink response");
-
-	if (resp.nh.nlmsg_type == NLMSG_ERROR && resp.err.error != 0) {
-		errno = -resp.err.error;
-		err(1, "failed to configure node id");
-	}
-
-	close(sock);
 }
 
 static void usage(void)


### PR DESCRIPTION
This function in qrtr-ns was largely copied from the main
function of qrtr-cfg. We should just factor it out so there is
one implementation instead.

Signed-off-by: Eric Caruso <ejcaruso@chromium.org>