### PR TITLE
lookup: fix service name for service type 17

### DIFF
--- a/src/lookup.c
+++ b/src/lookup.c
@@ -37,7 +37,7 @@ static const struct {
 	{ 14, 0, "Remote file system service" },
 	{ 15, 0, "Test service" },
 	{ 16, 0, "Location service (~ PDS v2)" },
-	{ 17, 0, "Service access proxy service" },
+	{ 17, 0, "Specific absorption rate service" },
 	{ 18, 0, "IMS settings service" },
 	{ 19, 0, "Analog to digital converter driver service" },
 	{ 20, 0, "Core sound driver service" },


### PR DESCRIPTION
Service type 17 (0x11) is Specific Absorption Rate service, while
service type 25 (0x19) is Service Access Proxy service.