### PR TITLE
libqrtr: add extern "C" guard in libqrtr.h

### DIFF
--- a/lib/libqrtr.h
+++ b/lib/libqrtr.h
@@ -6,6 +6,10 @@
 #include <sys/socket.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef offsetof
 #define offsetof(type, md) ((unsigned long)&((type *)0)->md)
 #endif
@@ -182,4 +186,9 @@ struct qrtr_ctrl_pkt {
 } __attribute__((packed));
 
 #endif
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
 #endif


### PR DESCRIPTION
This patch adds an extern "C" guard in libqrtr.h, so that it can be
included in both C and C++ projects.

Signed-off-by: Ben Chan <benchan@chromium.org>