### PR TITLE
qrtr-ns: initialize waiter_ticket struct in waiter_wait_timeout()

### DIFF
--- a/src/waiter.c
+++ b/src/waiter.c
@@ -266,6 +266,7 @@ int waiter_wait_timeout(struct waiter *w, unsigned int ms)
 	struct waiter_ticket ticket;
 	int rc;
 
+	memset(&ticket, 0, sizeof(ticket));
 	waiter_ticket_set_timeout(&ticket, ms);
 	list_append(&w->tickets, &ticket.list_item);
 	w->count++;


### PR DESCRIPTION
waiter_wait_timeout() doesn't initialize the 'callback' and 'updated'
fields of the waiter_ticket struct. The 'updated' field may contain some
garbage value, which is later read in waiter_ticket_check().

Signed-off-by: Ben Chan <benchan@chromium.org>