### PR TITLE
qmi: pass `const struct qrtr_packet' to qmi_decode_header()

### DIFF
--- a/lib/libqrtr.h
+++ b/lib/libqrtr.h
@@ -139,7 +139,7 @@ int qrtr_poll(int sock, unsigned int ms);
 int qrtr_decode(struct qrtr_packet *dest, void *buf, size_t len,
 		const struct sockaddr_qrtr *sq);
 
-int qmi_decode_header(struct qrtr_packet *pkt, unsigned int *msg_id);
+int qmi_decode_header(const struct qrtr_packet *pkt, unsigned int *msg_id);
 int qmi_decode_message(void *c_struct, unsigned int *txn,
 		       const struct qrtr_packet *pkt,
 		       int type, int id, struct qmi_elem_info *ei);

--- a/lib/qmi.c
+++ b/lib/qmi.c
@@ -792,9 +792,9 @@ ssize_t qmi_encode_message(struct qrtr_packet *pkt, int type, int msg_id,
 	return pkt->data_len;
 }
 
-int qmi_decode_header(struct qrtr_packet *pkt, unsigned int *msg_id)
+int qmi_decode_header(const struct qrtr_packet *pkt, unsigned int *msg_id)
 {
-	struct qmi_header *qmi = pkt->data;
+	const struct qmi_header *qmi = pkt->data;
 
 	if (qmi->msg_len != pkt->data_len - sizeof(*qmi)) {
 		LOGW("[RMTFS] Invalid length of incoming qmi request\n");


### PR DESCRIPTION
Similar to qmi_decode_message(), qmi_decode_header() doesn't modify the
`struct qrtr_packet` argument. This patch makes qmi_decode_header() to
take a `const struct qrtr_packet` argument like qmi_decode_message()
does.

Contributed by Jacob Rutherford <jruthe@chromium.org>