### PR TITLE
logging: add min priority and other cleanup

### DIFF
--- a/lib/logging.c
+++ b/lib/logging.c
@@ -7,6 +7,7 @@
 
 static const char default_tag[] = "libqrtr";
 static const char *current_tag = default_tag;
+static int min_priority = LOG_INFO;
 
 static bool logging_to_syslog = false;
 
@@ -14,6 +15,16 @@ void qlog_setup(const char *tag, bool use_syslog)
 {
 	current_tag = tag;
 	logging_to_syslog = use_syslog;
+
+	openlog(tag, LOG_PID, LOG_USER);
+}
+
+void qlog_set_min_priority(int priority)
+{
+	if (priority < LOG_EMERG || priority > LOG_DEBUG)
+		return;
+
+	min_priority = priority;
 }
 
 static const char *get_priority_string(int priority)
@@ -42,6 +53,10 @@ static const char *get_priority_string(int priority)
 void qlog(int priority, const char *format, ...)
 {
 	va_list ap;
+
+	if (priority > min_priority)
+		return;
+
 	va_start(ap, format);
 
 	if (logging_to_syslog) {

--- a/lib/logging.h
+++ b/lib/logging.h
@@ -12,8 +12,11 @@
 #endif
 
 void qlog_setup(const char *tag, bool use_syslog);
+void qlog_set_min_priority(int priority);
 
 void qlog(int priority, const char *format, ...) __PRINTF__(2, 3);
+
+#define LOGD(fmt, ...) qlog(LOG_DEBUG, fmt, ##__VA_ARGS__)
 
 #define LOGW(fmt, ...) qlog(LOG_WARNING, fmt, ##__VA_ARGS__)
 #define PLOGW(fmt, ...) \


### PR DESCRIPTION
The dprintf macro shadows a real libc symbol which is called
differently, so we should change it to something else (in this
case LOGD) and change it to use the libqrtr logging facilities.
This also means we should add a minimum priority to the logging
library so we don't log DEBUG-level messages by default.

Additionally there were some warn/warnx calls left over that
have been changed to PLOGW/LOGW respectively.