### PR TITLE
qrtr-ns.service: do not install as executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ $1: $1.in
 
 $(DESTDIR)$(servicedir)/$1: $1
 	@echo "INSTALL	$$<"
-	@install -D -m 755 $$< $$@
+	@install -D -m 644 $$< $$@
 
 all-install += $(DESTDIR)$(servicedir)/$1
 endef


### PR DESCRIPTION
Fix
systemd[1]: Configuration file /lib/systemd/system/qrtr-ns.service is marked executable. Please remove executable permission bits. Proceeding anyway.