### PR TITLE
libqrtr: Use size_t for offsets

### DIFF
--- a/lib/libqrtr.h
+++ b/lib/libqrtr.h
@@ -4,6 +4,7 @@
 #include <linux/qrtr.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -11,7 +12,7 @@ extern "C" {
 #endif
 
 #ifndef offsetof
-#define offsetof(type, md) ((unsigned long)&((type *)0)->md)
+#define offsetof(type, md) ((size_t)&((type *)0)->md)
 #endif
 
 #ifndef container_of
@@ -90,7 +91,7 @@ struct qmi_elem_info {
 	uint32_t elem_size;
 	enum qmi_array_type array_type;
 	uint8_t tlv_type;
-	uint32_t offset;
+	size_t offset;
 	struct qmi_elem_info *ei_array;
 };
 

--- a/src/list.h
+++ b/src/list.h
@@ -1,8 +1,10 @@
 #ifndef _LIST_H_
 #define _LIST_H_
 
+#include <stddef.h>
+
 #ifndef offsetof
-#define offsetof(type, md) ((unsigned long)&((type *)0)->md)
+#define offsetof(type, md) ((size_t)&((type *)0)->md)
 #endif
 
 #ifndef container_of


### PR DESCRIPTION
Currently, offsetof produces an unsigned long, while qmi_elem_info's
offset member is a uint32_t. Since this is not the same type on all
platforms, this change uses a size_t for both. stddef.h is also
included for the standard offsetof definition, which also produces a
size_t.

This change also makes similar modifications to list.h.