### PR TITLE
qrtr-lookup: Add DPM service name

### DIFF
--- a/src/lookup.c
+++ b/src/lookup.c
@@ -64,6 +64,7 @@ static const struct {
 	{ 41, 0, "RF radiated performance enhancement service" },
 	{ 42, 0, "Data system determination service" },
 	{ 43, 0, "Subsystem control service" },
+	{ 47, 0, "Data Port Mapper service" },
 	{ 49, 0, "IPA control service" },
 	{ 51, 0, "CoreSight remote tracing service" },
 	{ 52, 0, "Dynamic Heap Memory Sharing" },


### PR DESCRIPTION
Data Port Mapper service is ID 47.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>