### PR TITLE
Misc fixes for qrild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ $(proj)-lookup-cflags := -Ilib
 
 lib$(proj).so-srcs := \
 	lib/logging.c \
+	lib/qmi_tlv.c \
 	lib/qrtr.c \
 	lib/qmi.c
 

--- a/lib/libqrtr.h
+++ b/lib/libqrtr.h
@@ -178,8 +178,17 @@ void *qmi_tlv_get_array(struct qmi_tlv *tlv, uint8_t id, size_t len_size,
 int qmi_tlv_set(struct qmi_tlv *tlv, uint8_t id, void *buf, size_t len);
 int qmi_tlv_set_array(struct qmi_tlv *tlv, uint8_t id, size_t len_size,
 		      void *buf, size_t len, size_t size);
-
 struct qmi_response_type_v01 *qmi_tlv_get_result(struct qmi_tlv *tlv);
+
+static inline int qmi_tlv_dump_buf(void *buf, size_t len) {
+	struct qmi_tlv *tlv = qmi_tlv_decode(buf, len);
+	if (!tlv)
+		return -1;
+	qmi_tlv_dump(tlv);
+	qmi_tlv_free(tlv);
+
+	return 0;
+}
 
 /* Initial kernel header didn't expose these */
 #ifndef QRTR_NODE_BCAST

--- a/lib/libqrtr.h
+++ b/lib/libqrtr.h
@@ -25,6 +25,7 @@ extern "C" {
 #endif
 
 struct sockaddr_qrtr;
+struct qmi_tlv;
 
 struct qrtr_packet {
 	int type;
@@ -165,6 +166,20 @@ int qmi_decode_message(void *c_struct, unsigned int *txn,
 ssize_t qmi_encode_message(struct qrtr_packet *pkt, int type, int msg_id,
 			   int txn_id, const void *c_struct,
 			   struct qmi_elem_info *ei);
+
+struct qmi_tlv *qmi_tlv_init(uint16_t txn, uint32_t msg_id, uint32_t msg_type);
+void *qmi_tlv_encode(struct qmi_tlv *tlv, size_t *len);
+struct qmi_tlv *qmi_tlv_decode(void *buf, size_t len);
+void qmi_tlv_free(struct qmi_tlv *tlv);
+void qmi_tlv_dump(struct qmi_tlv *tlv);
+void *qmi_tlv_get(struct qmi_tlv *tlv, uint8_t id, size_t *len);
+void *qmi_tlv_get_array(struct qmi_tlv *tlv, uint8_t id, size_t len_size,
+			size_t *len, size_t *size);
+int qmi_tlv_set(struct qmi_tlv *tlv, uint8_t id, void *buf, size_t len);
+int qmi_tlv_set_array(struct qmi_tlv *tlv, uint8_t id, size_t len_size,
+		      void *buf, size_t len, size_t size);
+
+struct qmi_response_type_v01 *qmi_tlv_get_result(struct qmi_tlv *tlv);
 
 /* Initial kernel header didn't expose these */
 #ifndef QRTR_NODE_BCAST

--- a/lib/libqrtr.h
+++ b/lib/libqrtr.h
@@ -40,6 +40,20 @@ struct qrtr_packet {
 	size_t data_len;
 };
 
+/**
+ * qmi_header - wireformat header of QMI messages
+ * @type:       type of message
+ * @txn_id:     transaction id
+ * @msg_id:     message id
+ * @msg_len:    length of message payload following header
+ */
+struct qmi_header {
+	uint8_t type;
+	uint16_t txn_id;
+	uint16_t msg_id;
+	uint16_t msg_len;
+} __attribute__((packed));
+
 #define DEFINE_QRTR_PACKET(pkt, size) \
 	char pkt ## _buf[size]; \
 	struct qrtr_packet pkt = { .data = pkt ##_buf, \
@@ -141,7 +155,10 @@ int qrtr_poll(int sock, unsigned int ms);
 int qrtr_decode(struct qrtr_packet *dest, void *buf, size_t len,
 		const struct sockaddr_qrtr *sq);
 
+const struct qmi_header *qmi_get_header(const struct qrtr_packet *pkt);
 int qmi_decode_header(const struct qrtr_packet *pkt, unsigned int *msg_id);
+int qmi_decode_header2(const struct qrtr_packet *pkt, unsigned int *msg_id, unsigned char *type,
+		       unsigned short *txn_id);
 int qmi_decode_message(void *c_struct, unsigned int *txn,
 		       const struct qrtr_packet *pkt,
 		       int type, int id, struct qmi_elem_info *ei);

--- a/lib/libqrtr.h
+++ b/lib/libqrtr.h
@@ -167,11 +167,23 @@ ssize_t qmi_encode_message(struct qrtr_packet *pkt, int type, int msg_id,
 			   int txn_id, const void *c_struct,
 			   struct qmi_elem_info *ei);
 
+struct qmi_tlv {
+	void *allocated;
+	void *buf;
+	size_t size;
+	int error;
+};
+
+struct qmi_tlv_item {
+	uint8_t key;
+	uint16_t len;
+	uint8_t data[];
+} __attribute__((__packed__));
+
 struct qmi_tlv *qmi_tlv_init(uint16_t txn, uint32_t msg_id, uint32_t msg_type);
 void *qmi_tlv_encode(struct qmi_tlv *tlv, size_t *len);
 struct qmi_tlv *qmi_tlv_decode(void *buf, size_t len);
 void qmi_tlv_free(struct qmi_tlv *tlv);
-void qmi_tlv_dump(struct qmi_tlv *tlv);
 void *qmi_tlv_get(struct qmi_tlv *tlv, uint8_t id, size_t *len);
 void *qmi_tlv_get_array(struct qmi_tlv *tlv, uint8_t id, size_t len_size,
 			size_t *len, size_t *size);
@@ -180,15 +192,6 @@ int qmi_tlv_set_array(struct qmi_tlv *tlv, uint8_t id, size_t len_size,
 		      void *buf, size_t len, size_t size);
 struct qmi_response_type_v01 *qmi_tlv_get_result(struct qmi_tlv *tlv);
 
-static inline int qmi_tlv_dump_buf(void *buf, size_t len) {
-	struct qmi_tlv *tlv = qmi_tlv_decode(buf, len);
-	if (!tlv)
-		return -1;
-	qmi_tlv_dump(tlv);
-	qmi_tlv_free(tlv);
-
-	return 0;
-}
 
 /* Initial kernel header didn't expose these */
 #ifndef QRTR_NODE_BCAST

--- a/lib/libqrtr.h
+++ b/lib/libqrtr.h
@@ -180,6 +180,11 @@ struct qmi_tlv_item {
 	uint8_t data[];
 } __attribute__((__packed__));
 
+struct qmi_tlv_msg_name {
+	int msg_id;
+	const char *msg_name;
+};
+
 struct qmi_tlv *qmi_tlv_init(uint16_t txn, uint32_t msg_id, uint32_t msg_type);
 void *qmi_tlv_encode(struct qmi_tlv *tlv, size_t *len);
 struct qmi_tlv *qmi_tlv_decode(void *buf, size_t len);

--- a/lib/logging.h
+++ b/lib/logging.h
@@ -5,6 +5,10 @@
 #include <stdlib.h>
 #include <syslog.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if defined(__GNUC__) || defined(__clang__)
 #define __PRINTF__(fmt, args) __attribute__((format(__printf__, fmt, args)))
 #else
@@ -32,5 +36,9 @@ void qlog(int priority, const char *format, ...) __PRINTF__(2, 3);
 		qlog(LOG_ERR, fmt ": %s", ##__VA_ARGS__, strerror(errno));	\
 		exit(1);							\
 	} while(0)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #endif

--- a/lib/logging.h
+++ b/lib/logging.h
@@ -38,7 +38,7 @@ void qlog(int priority, const char *format, ...) __PRINTF__(2, 3);
 	} while(0)
 
 #ifdef __cplusplus
-extern "C" {
+}
 #endif
 
 #endif

--- a/lib/qmi.c
+++ b/lib/qmi.c
@@ -36,21 +36,6 @@
 #include "libqrtr.h"
 #include "logging.h"
 
-/**
- * qmi_header - wireformat header of QMI messages
- * @type:       type of message
- * @txn_id:     transaction id
- * @msg_id:     message id
- * @msg_len:    length of message payload following header
- */
-struct qmi_header {
-	uint8_t type;
-	uint16_t txn_id;
-	uint16_t msg_id;
-	uint16_t msg_len;
-} __attribute__((packed));
-
-
 #define QMI_ENCDEC_ENCODE_TLV(type, length, p_dst) do { \
 	*p_dst++ = type; \
 	*p_dst++ = ((uint8_t)((length) & 0xFF)); \
@@ -794,16 +779,40 @@ ssize_t qmi_encode_message(struct qrtr_packet *pkt, int type, int msg_id,
 	return pkt->data_len;
 }
 
-int qmi_decode_header(const struct qrtr_packet *pkt, unsigned int *msg_id)
+const struct qmi_header *qmi_get_header(const struct qrtr_packet *pkt)
 {
 	const struct qmi_header *qmi = pkt->data;
 
 	if (qmi->msg_len != pkt->data_len - sizeof(*qmi)) {
-		LOGW("[RMTFS] Invalid length of incoming qmi request\n");
-		return -EINVAL;
+		LOGW("[QRTR] Invalid length of incoming qmi request\n");
+		return NULL;
 	}
 
+	return qmi;
+}
+
+int qmi_decode_header(const struct qrtr_packet *pkt, unsigned int *msg_id)
+{
+	const struct qmi_header *qmi = qmi_get_header(pkt);
+
 	*msg_id = qmi->msg_id;
+
+	return 0;
+}
+
+int qmi_decode_header2(const struct qrtr_packet *pkt, unsigned int *msg_id, unsigned char *type,
+		       unsigned short *txn_id)
+{
+	const struct qmi_header *qmi = qmi_get_header(pkt);
+	if (!qmi)
+		return -1;
+
+	if (type)
+		*type = qmi->type;
+	if (msg_id)
+		*msg_id = qmi->msg_id;
+	if (txn_id)
+		*txn_id = qmi->txn_id;
 
 	return 0;
 }

--- a/lib/qmi_tlv.c
+++ b/lib/qmi_tlv.c
@@ -43,7 +43,6 @@ struct qmi_tlv *qmi_tlv_init(uint16_t txn, uint32_t msg_id, uint32_t msg_type)
 
 struct qmi_tlv *qmi_tlv_decode(void *buf, size_t len)
 {
-	struct qmi_header *pkt = buf;
 	struct qmi_tlv *tlv;
 
 	tlv = malloc(sizeof(struct qmi_tlv));
@@ -247,13 +246,13 @@ void qmi_tlv_dump(struct qmi_tlv *tlv) {
 	char line[LINE_LENGTH * 4 + 1];
 
 	pkt = tlv->buf;
-	pkt_data = &pkt[1];
+	pkt_data = &pkt[0];
 
 	printf("<<< Message:\n");
 	printf("<<<    type    : %u\n", pkt->type);
-	printf("<<<    msg_len : %u\n", pkt->msg_len);
-	printf("<<<    msg_id  : 0x%04x\n", pkt->msg_id);
-	printf("<<<    txn_id  : %u\n", pkt->txn_id);
+	printf("<<<    msg_len : 0x%1$04x (%1$u)\n", pkt->msg_len);
+	printf("<<<    msg_id  : 0x%1$04x (%1$u)\n", pkt->msg_id);
+	printf("<<<    txn_id  : 0x%1$04x (%1$u)\n", pkt->txn_id);
 	printf("<<< TLVs:\n");
 	while (offset < tlv->size - sizeof(struct qmi_header)) {
 		item = pkt_data + offset;

--- a/lib/qmi_tlv.c
+++ b/lib/qmi_tlv.c
@@ -1,0 +1,282 @@
+#include <errno.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "libqrtr.h"
+
+struct qmi_tlv {
+	void *allocated;
+	void *buf;
+	size_t size;
+	int error;
+};
+
+struct qmi_tlv_item {
+	uint8_t key;
+	uint16_t len;
+	uint8_t data[];
+} __attribute__((__packed__));
+
+struct qmi_tlv *qmi_tlv_init(uint16_t txn, uint32_t msg_id, uint32_t msg_type)
+{
+	struct qmi_header *pkt;
+	struct qmi_tlv *tlv;
+
+	tlv = malloc(sizeof(struct qmi_tlv));
+	memset(tlv, 0, sizeof(struct qmi_tlv));
+
+	tlv->size = sizeof(struct qmi_header);
+	tlv->allocated = malloc(tlv->size);
+	tlv->buf = tlv->allocated;
+
+	pkt = tlv->buf;
+	pkt->type = msg_type;
+	pkt->txn_id = txn;
+	pkt->msg_id = msg_id;
+	pkt->msg_len = 0;
+
+	return tlv;
+}
+
+struct qmi_tlv *qmi_tlv_decode(void *buf, size_t len)
+{
+	struct qmi_header *pkt = buf;
+	struct qmi_tlv *tlv;
+
+	tlv = malloc(sizeof(struct qmi_tlv));
+	memset(tlv, 0, sizeof(struct qmi_tlv));
+
+	tlv->buf = buf;
+	tlv->size = len;
+
+	return tlv;
+}
+
+void *qmi_tlv_encode(struct qmi_tlv *tlv, size_t *len)
+{
+	struct qmi_header *pkt;
+
+	if (!tlv || tlv->error)
+		return NULL;
+
+	pkt = tlv->buf;
+	pkt->msg_len = tlv->size - sizeof(struct qmi_header);
+
+	*len = tlv->size;
+	return tlv->buf;
+}
+
+void qmi_tlv_free(struct qmi_tlv *tlv)
+{
+	free(tlv->allocated);
+	free(tlv);
+}
+
+static struct qmi_tlv_item *qmi_tlv_get_item(struct qmi_tlv *tlv, unsigned id)
+{
+	struct qmi_tlv_item *item;
+	struct qmi_header *pkt;
+	unsigned offset = 0;
+	void *pkt_data;
+
+	pkt = tlv->buf;
+	pkt_data = &pkt[1];
+
+	while (offset < tlv->size) {
+		item = pkt_data + offset;
+		if (item->key == id)
+			return pkt_data + offset;
+
+		offset += sizeof(struct qmi_tlv_item) + item->len;
+	}
+	return NULL;
+}
+
+void *qmi_tlv_get(struct qmi_tlv *tlv, uint8_t id, size_t *len)
+{
+	struct qmi_tlv_item *item;
+
+	item = qmi_tlv_get_item(tlv, id);
+	if (!item)
+		return NULL;
+
+	if (len)
+		*len = item->len;
+	return item->data;
+}
+
+void *qmi_tlv_get_array(struct qmi_tlv *tlv, uint8_t id, size_t len_size,
+			size_t *len, size_t *size)
+{
+	struct qmi_tlv_item *item;
+	unsigned count;
+	void *ptr;
+
+	item = qmi_tlv_get_item(tlv, id);
+	if (!item)
+		return NULL;
+
+	ptr = item->data;
+	switch (len_size) {
+	case 4:
+		count = *(uint32_t *)ptr++;
+		break;
+	case 2:
+		count = *(uint16_t *)ptr++;
+		break;
+	case 1:
+		count = *(uint8_t *)ptr++;
+		break;
+	default:
+		return NULL;
+	}
+
+	*len = count;
+	*size = (item->len - len_size) / count;
+
+	return ptr;
+}
+
+static struct qmi_tlv_item *qmi_tlv_alloc_item(struct qmi_tlv *tlv, unsigned id,
+					       size_t len)
+{
+	struct qmi_tlv_item *item;
+	size_t new_size;
+	bool migrate;
+	void *newp;
+
+	/* If using user provided buffer, migrate data */
+	migrate = !tlv->allocated;
+
+	new_size = tlv->size + sizeof(struct qmi_tlv_item) + len;
+	newp = realloc(tlv->allocated, new_size);
+	if (!newp)
+		return NULL;
+
+	if (migrate)
+		memcpy(newp, tlv->buf, tlv->size);
+
+	item = newp + tlv->size;
+	item->key = id;
+	item->len = len;
+
+	tlv->buf = tlv->allocated = newp;
+	tlv->size = new_size;
+
+	return item;
+}
+
+int qmi_tlv_set(struct qmi_tlv *tlv, uint8_t id, void *buf, size_t len)
+{
+	struct qmi_tlv_item *item;
+
+	if (!tlv)
+		return -EINVAL;
+
+	item = qmi_tlv_alloc_item(tlv, id, len);
+	if (!item) {
+		tlv->error = ENOMEM;
+		return -ENOMEM;
+	}
+
+	memcpy(item->data, buf, len);
+
+	return 0;
+}
+
+int qmi_tlv_set_array(struct qmi_tlv *tlv, uint8_t id, size_t len_size,
+		      void *buf, size_t len, size_t size)
+{
+	struct qmi_tlv_item *item;
+	size_t array_size;
+	void *ptr;
+
+	if (!tlv)
+		return -EINVAL;
+
+	array_size = len * size;
+	item = qmi_tlv_alloc_item(tlv, id, len_size + array_size);
+	if (!item) {
+		tlv->error = ENOMEM;
+		return -ENOMEM;
+	}
+
+	ptr = item->data;
+
+	switch (len_size) {
+	case 4:
+		*(uint32_t *)ptr++ = len;
+		break;
+	case 2:
+		*(uint16_t *)ptr++ = len;
+		break;
+	case 1:
+		*(uint8_t *)ptr++ = len;
+		break;
+	}
+	memcpy(ptr, buf, array_size);
+
+	return 0;
+}
+
+struct qmi_response_type_v01 *qmi_tlv_get_result(struct qmi_tlv *tlv)
+{
+	return qmi_tlv_get(tlv, 2, NULL);
+}
+
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+#define LINE_LENGTH 64
+
+static inline uint8_t to_hex(uint8_t ch)
+{
+	ch &= 0xf;
+	return ch <= 9 ? '0' + ch : 'a' + ch - 10;
+}
+
+void qmi_tlv_dump(struct qmi_tlv *tlv) {
+	struct qmi_tlv_item *item;
+	struct qmi_header *pkt;
+	unsigned offset = 0;
+	void *pkt_data;
+	int i = 0, li, j, k;
+	uint8_t ch;
+	size_t linelen;
+	char line[LINE_LENGTH * 4 + 1];
+
+	pkt = tlv->buf;
+	pkt_data = &pkt[1];
+
+	printf("<<< Message:\n");
+	printf("<<<    type    : %u\n", pkt->type);
+	printf("<<<    msg_len : %u\n", pkt->msg_len);
+	printf("<<<    msg_id  : 0x%04x\n", pkt->msg_id);
+	printf("<<<    txn_id  : %u\n", pkt->txn_id);
+	printf("<<< TLVs:\n");
+	while (offset < tlv->size - sizeof(struct qmi_header)) {
+		item = pkt_data + offset;
+		printf("<<< TLV %d: {id: 0x%02x, len: 0x%02x}\n", i, item->key, item->len);
+		if (item->len > pkt->msg_len - offset) {
+			fprintf(stderr, "Invalid item length!\n");
+			return;
+		}
+		for (j = 0; j < item->len; j += LINE_LENGTH) {
+			linelen = MIN(LINE_LENGTH, item->len - j);
+			li = 0;
+
+			for (k = 0; k < linelen; k++) {
+				ch = item->data[j + k];
+				line[li++] = to_hex(ch >> 4);
+				line[li++] = to_hex(ch);
+				line[li++] = k < linelen - 1 ? ':' : ' ';
+			}
+			line[li] = '\0';
+
+			printf("%s\n\n", line);
+		}
+		offset += sizeof(struct qmi_tlv_item) + item->len;
+		i++;
+	}
+}


### PR DESCRIPTION
Export the whole QMI header, and add qmi_tlv to libqrtr so projects using the "accessor" style QMI code generator don't have to vendor it.

I've made some changes to the qmi_tlv_* interface which are reflected in my fork of qmic: https://github.com/calebccff/qmic/tree/nested_structs, I'll also be opening a PR for that soon, any feedback on the qmi_tlv_* interface would be good before opening that.