### PR TITLE
lookup: add Snapdragon Sensor Core service

### DIFF
--- a/src/lookup.c
+++ b/src/lookup.c
@@ -75,6 +75,7 @@ static const struct {
 	{ 225, 0, "Remote Management Service" },
 	{ 226, 0, "Open Mobile Alliance device management service" },
 	{ 312, 0, "QBT1000 Ultrasonic Fingerprint Sensor service" },
+	{ 400, 0, "Snapdragon Sensor Core service" },
 	{ 769, 0, "SLIMbus control service" },
 	{ 771, 0, "Peripheral Access Control Manager service" },
 	{ 4096, 0, "TFTP" },


### PR DESCRIPTION
SDM845 and later expose a Snapdragon Sensor Core service (400) to access the sensors
 managed by a remoteproc. Add this service to the known list of services.

Signed-off-by: Dylan Van Assche <me@dylanvanassche.be>