### PR TITLE
Makefile: allow $(CFLAGS), $(LDFLAGS) override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,9 @@ proj-major := 1
 proj-minor := 0
 proj-version := $(proj-major).$(proj-minor)
 
-CFLAGS := -Wall -g
-LDFLAGS :=
+CFLAGS += -Wall -g
+prefix = /usr/local
 
-prefix := /usr/local
 bindir := $(prefix)/bin
 libdir := $(prefix)/lib
 includedir := $(prefix)/include


### PR DESCRIPTION
The caller might have specified CFLAGS or LDFLAGS. Let's respect those.
Additionally drop LDFLAGS var definition as it is empty.

See https://github.com/andersson/rmtfs/commit/5eb67a1fb5a5238f3d560b38505b891285eb3c45 for something similar already done on `rmtfs` previously.