### PR TITLE
Makefile: remove generated service file when cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ $(DESTDIR)$(servicedir)/$1: $1
 	@echo "INSTALL	$$<"
 	@install -D -m 644 $$< $$@
 
+all-clean += $1
 all-install += $(DESTDIR)$(servicedir)/$1
 endef
 


### PR DESCRIPTION
After building the package, `make clean` doesn't delete the generated service file. This patch ensures this file is included in the `$(all-clean)` variable so it is removed when cleaning.