### PR TITLE
lib: meson.build: restore libqrtr SONAME

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -5,6 +5,7 @@ pkg = import('pkgconfig')
 libqrtr_srcs = ['logging.c', 'qmi.c', 'qrtr.c']
 libqrtr = shared_library('qrtr',
                          libqrtr_srcs,
+                         version: meson.project_version(),
                          include_directories : inc,
                          install: true)
 

--- a/meson.build
+++ b/meson.build
@@ -2,6 +2,7 @@
 
 project('qrtr',
         'c',
+        version: '1.1',
         license : [ 'BSD-3-Clause'],
         default_options : [
         'warning_level=1',


### PR DESCRIPTION
The previous version of `libqrtr` had `libqrtr.so.1` as their SONAME, while the current version have only `libqrtr.so`. This is problematic as previously built binaries using this lib will have to be rebuilt for this new version (or rather, re-linked, which is practically equivalent).

This change ensures the SONAME is kept by setting the project version in the top-level `meson.build` and uses this string as the shared library version.

In practice, the generated library filename is now `libqrtr.so.1.1` with SONAME still being `libqrtr.so.1`.