### PR TITLE
meson: Specify project and library version

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -6,6 +6,7 @@ libqrtr_srcs = ['logging.c', 'qmi.c', 'qrtr.c']
 libqrtr = shared_library('qrtr',
                          libqrtr_srcs,
                          include_directories : inc,
-                         install: true)
+                         install : true,
+                         version : meson.project_version())
 
 pkg.generate(libqrtr)

--- a/meson.build
+++ b/meson.build
@@ -3,6 +3,7 @@
 project('qrtr',
         'c',
         license : [ 'BSD-3-Clause'],
+        version : '1.1',
         default_options : [
         'warning_level=1',
         'buildtype=release',


### PR DESCRIPTION
Specify project version in meson `project()` call.
Withouth this in generated `qrtr.pc` pkg-config file version will be undefined, and this is a packaging error. E.g. Alpine Linux's build system doesn't allow this to pass.

Specify also shared library soversion.
This reults in library being called `libqrtr.so.1.1` and symlinks generated and installed as:

```
 libqrtr.so -> libqrtr.so.1
 libqrtr.so.1 -> libqrtr.so.1.1
```

This is important for -dev subpackage.