### PR TITLE
lookup: add Sensor Manager (SMGR) service IDs

### DIFF
--- a/src/lookup.c
+++ b/src/lookup.c
@@ -86,6 +86,8 @@ static const struct {
 	{ 226, 0, "Open Mobile Alliance device management service" },
 	{ 231, 0, "Vendor-specific service" },
 	{ 235, 0, "Modem service" },
+	{ 256, 0, "Sensor Manager service" },
+	{ 271, 0, "Sensor Registry service" },
 	{ 312, 0, "QBT1000 Ultrasonic Fingerprint Sensor service" },
 	{ 400, 0, "Snapdragon Sensor Core service" },
 	{ 769, 0, "SLIMbus control service" },


### PR DESCRIPTION
On some older SoCs (older than SDM845) downstream userspace starts a Sensor Registry service (271) to provide sensor configuration information to a remote processor (SDSP or ADSP). After receiving registry data, SDSP or ADSP exposes a Sensor Manager service "SMGR" (256), which allows to access sensor readings. Add these services to the known list of services.

Tested on sdm660 device with userspace sns-reg service running:
```
$ qrtr-lookup | grep -i sens
       23       1        0    0    23 Thermal sensors service
     4097 N/A      192    1 16401 DIAG service (SENSORS:CNTL)
     4097 N/A      194    1 16403 DIAG service (SENSORS:DATA)
     4097 N/A      196    1 16404 DIAG service (SENSORS:DCI)
      271       2        0    1 16418 Sensor Registry service
      256       1       50    5    60 Sensor Manager service
```
(last 2 lines with IDs 256 & 271)