### PR TITLE
lib: meson.build: Don't force shared libqrtr

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -3,10 +3,10 @@
 pkg = import('pkgconfig')
 
 libqrtr_srcs = ['logging.c', 'qmi.c', 'qrtr.c']
-libqrtr = shared_library('qrtr',
-                         libqrtr_srcs,
-                         version: meson.project_version(),
-                         include_directories : inc,
-                         install: true)
+libqrtr = library('qrtr',
+                  libqrtr_srcs,
+                  version: meson.project_version(),
+                  include_directories : inc,
+                  install: true)
 
 pkg.generate(libqrtr)


### PR DESCRIPTION
Allow the build system to build a static version of libqrtr when the user requests it.

As per meson manual:
> You should use this [library()] instead of shared_library(),
> static_library() or both_libraries() most of the time.

---

For reference for building a static aarch64 binary of qrtr-lookup:
```
podman run --rm -it --platform=linux/arm64 -v $PWD:/data alpine:edge
# apk add meson gcc musl-dev qrtr-dev
# cd /data
# LDFLAGS="-static -static-libgcc" meson setup builddir -Ddefault_library=static
# meson compile -C builddir/
```