### PR TITLE
ci: refresh matrix and add Android NDK cross-compile job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         echo "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
 
     - name: Git checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Install additional packages
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         family: [x86-64]
         compiler: [gcc, clang]
         container:
+          - alpine:edge
+          - alpine:latest
           - archlinux:latest
           - debian:testing
           - debian:stable
@@ -40,9 +42,8 @@ jobs:
           # Fails on configure on GCC and clang (process restrictions?)
           # - fedora:rawhide
           - fedora:latest
-          - fedora:39
-          - fedora:38
-          - fedora:37
+          - ubuntu:latest
+          - ubuntu:noble
           - ubuntu:jammy
           - ubuntu:focal
           # On Ubuntu Bionic the Meson doesn't support feature options
@@ -52,17 +53,6 @@ jobs:
         cross_compile: [""]
         variant: [""]
         include:
-          # Alpine (OpenRC)
-          - container: "alpine:edge"
-            arch: x86-64
-            family: x86-64
-            compiler: gcc
-
-          - container: "alpine:latest"
-            arch: x86-64
-            family: x86-64
-            compiler: gcc
-
           # Debian 32-bit builds
           - container: "debian:testing"
             arch: i386

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,3 +232,47 @@ jobs:
 
     - name: Install
       run: ninja -C build install
+
+  android:
+    name: Android
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        abi: [arm64-v8a, armeabi-v7a, x86_64]
+
+    env:
+      NDK_VERSION: r27d
+      API: "24"
+      ABI: ${{ matrix.abi }}
+
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v5
+
+    - name: Install build tools
+      run: |
+        sudo apt update
+        sudo apt install -y --no-install-recommends meson ninja-build
+
+    - name: Cache Android NDK
+      id: ndk-cache
+      uses: actions/cache@v4
+      with:
+        path: android-ndk-${{ env.NDK_VERSION }}
+        key: ndk-${{ env.NDK_VERSION }}-linux
+
+    - name: Download Android NDK
+      if: steps.ndk-cache.outputs.cache-hit != 'true'
+      run: |
+        curl -sSLO https://dl.google.com/android/repository/android-ndk-${NDK_VERSION}-linux.zip
+        unzip -q android-ndk-${NDK_VERSION}-linux.zip
+        rm android-ndk-${NDK_VERSION}-linux.zip
+
+    - name: Build for Android
+      run: |
+        export ANDROID_NDK="$GITHUB_WORKSPACE/android-ndk-${NDK_VERSION}"
+        ./ci/android.sh

--- a/ci/alpine.sh
+++ b/ci/alpine.sh
@@ -17,6 +17,7 @@ case $CC in
 esac
 
 apk add \
+	build-base \
 	linux-headers \
 	meson \
 	musl-dev \

--- a/ci/android.sh
+++ b/ci/android.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+#
+# Cross-build qrtr for Android using the NDK.
+#
+# Expects the following environment variables:
+#   ABI          - Android ABI (arm64-v8a, armeabi-v7a, x86_64)
+#   API          - Android API level to target
+#   ANDROID_NDK  - path to an unpacked Android NDK
+
+set -ex
+
+TOOLCHAIN="$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64"
+
+case "$ABI" in
+	arm64-v8a)
+		CPU_FAMILY=aarch64
+		CPU=aarch64
+		TRIPLE=aarch64-linux-android
+		ELF_MACHINE=AArch64
+	;;
+	armeabi-v7a)
+		CPU_FAMILY=arm
+		CPU=armv7a
+		TRIPLE=armv7a-linux-androideabi
+		ELF_MACHINE=ARM
+	;;
+	x86_64)
+		CPU_FAMILY=x86_64
+		CPU=x86_64
+		TRIPLE=x86_64-linux-android
+		ELF_MACHINE=X86-64
+	;;
+	*)
+		echo "Unknown ABI '$ABI'" >&2
+		exit 1
+	;;
+esac
+
+# The per-ABI clang wrapper already selects the correct target and sysroot, so
+# the cross file does not need to spell those out.
+cat > android-cross.txt <<EOF
+[binaries]
+c = '$TOOLCHAIN/bin/${TRIPLE}${API}-clang'
+ar = '$TOOLCHAIN/bin/llvm-ar'
+strip = '$TOOLCHAIN/bin/llvm-strip'
+
+[host_machine]
+system = 'android'
+cpu_family = '$CPU_FAMILY'
+cpu = '$CPU'
+endian = 'little'
+EOF
+cat android-cross.txt
+
+# Android.bp builds qrtr with -Wno-error, so do not force -Werror here.
+meson setup --errorlogs --cross-file android-cross.txt . build
+ninja -C build
+
+# Confirm the resulting binary really is for the requested ABI.
+"$TOOLCHAIN/bin/llvm-readelf" -h build/src/qrtr-cfg | grep -q "Machine:.*$ELF_MACHINE"
+echo "Android build for $ABI ($ELF_MACHINE) succeeded"


### PR DESCRIPTION
Align the qrtr GitHub Actions workflow with the recent cdba CI cleanups
and add an Android build to catch bionic-specific regressions.